### PR TITLE
Set config_flow to true to enable manual UI configuration

### DIFF
--- a/custom_components/astralpool_chlorinator/manifest.json
+++ b/custom_components/astralpool_chlorinator/manifest.json
@@ -9,7 +9,7 @@
   "codeowners": [
     "@pbutterworth"
   ],
-  "config_flow": false,
+  "config_flow": true,
   "dependencies": [
     "bluetooth_adapters"
   ],
@@ -21,5 +21,5 @@
     "bluetooth-data-tools>=0.4.0",
     "pychlorinator>=0.2.14b2"
   ],
-  "version": "0.1.13b1"
+  "version": "0.1.14"
 }


### PR DESCRIPTION
## Summary

Enables manual UI configuration via Settings → Integrations → Add Integration.

Previously `config_flow` was set to `false` in the manifest, meaning the integration could only be added via Bluetooth auto-discovery. If auto-discovery fails (e.g. device out of range during HA startup, or the user wants to manually configure), there was no  way to add the integration without restarting HA and hoping for discovery.

## Changes
- `manifest.json`: `config_flow: false` → `config_flow: true`
- Version bump to `0.1.14`

## Testing
- Tested on Home Assistant 2026.4.4 and 2026.5.1
- Manual add via UI confirmed working on Astral Pool Viron EQ25

## Notes
- No breaking changes — existing installations unaffected
- Auto-discovery still works as before