### PR TITLE
Add number, button and select platforms for chlorinator write control

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 | --------------- | ------------------------------------------------------------------------- |
 | `binary_sensor` | Show something `True` or `False`.                                         |
 | `sensor`        | Show info from Astral Pool Viron eQuilibrium Chlorinator API.             |
-| `select`        | Control the chlorinator mode (off/auto/manual)                            |
+| `select`        | Control the chlorinator mode (off/auto/manual), pump speed, and default manual speed. |
+| `number`        | Set pH setpoint, chlorine output level (0-8 manual / ORP mV automatic), and acid dosing inhibit period. |
+| `button`        | Dismiss info message, disable/re-enable acid dosing, reset statistics, trigger cell reversal. |
 
 
 ## Installation

--- a/custom_components/astralpool_chlorinator/__init__.py
+++ b/custom_components/astralpool_chlorinator/__init__.py
@@ -17,7 +17,7 @@ from .const import DOMAIN
 from .coordinator import ChlorinatorDataUpdateCoordinator
 from .models import ChlorinatorData
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SELECT, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/astralpool_chlorinator/button.py
+++ b/custom_components/astralpool_chlorinator/button.py
@@ -1,0 +1,118 @@
+"""Platform for button integration."""
+from __future__ import annotations
+
+import logging
+
+from pychlorinator.chlorinator_parsers import ChlorinatorActions
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import ChlorinatorDataUpdateCoordinator
+from .models import ChlorinatorData
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DEVICE_INFO = {
+    "identifiers": {(DOMAIN, "POOL01")},
+    "name": "POOL01",
+    "model": "Viron eQuilibrium",
+    "manufacturer": "Astral Pool",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Chlorinator button entities from a config entry."""
+    data: ChlorinatorData = hass.data[DOMAIN][entry.entry_id]
+    entities = [
+        ChlorinatorDismissInfoMessageButton(data.coordinator),
+        ChlorinatorDisableAcidDosingIndefinitelyButton(data.coordinator),
+        ChlorinatorReenableAcidDosingButton(data.coordinator),
+        ChlorinatorResetStatisticsButton(data.coordinator),
+        ChlorinatorTriggerCellReversalButton(data.coordinator),
+    ]
+    async_add_entities(entities)
+
+
+class ChlorinatorButtonBase(
+    CoordinatorEntity[ChlorinatorDataUpdateCoordinator], ButtonEntity
+):
+    """Base class for Chlorinator button entities."""
+
+    _action: ChlorinatorActions = ChlorinatorActions.NoAction
+
+    def __init__(self, coordinator: ChlorinatorDataUpdateCoordinator) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return DEVICE_INFO
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_action(self._action)
+        await self.coordinator.async_request_refresh()
+
+
+class ChlorinatorDismissInfoMessageButton(ChlorinatorButtonBase):
+    """Button to dismiss the current info message."""
+
+    _attr_icon = "mdi:close-circle-outline"
+    _attr_name = "Dismiss Info Message"
+    _attr_unique_id = "pool01_dismiss_info_message_button"
+    _action = ChlorinatorActions.DismissInfoMessage
+
+
+class ChlorinatorDisableAcidDosingIndefinitelyButton(ChlorinatorButtonBase):
+    """Button to disable acid dosing indefinitely."""
+
+    _attr_icon = "mdi:beaker-off-outline"
+    _attr_name = "Disable Acid Dosing"
+    _attr_unique_id = "pool01_disable_acid_dosing_indefinitely_button"
+    _action = ChlorinatorActions.DisableAcidDosingIndefinitely
+
+
+class ChlorinatorReenableAcidDosingButton(ChlorinatorButtonBase):
+    """Button to re-enable acid dosing by sending period=0."""
+
+    _attr_icon = "mdi:beaker-check-outline"
+    _attr_name = "Re-enable Acid Dosing"
+    _attr_unique_id = "pool01_reenable_acid_dosing_button"
+
+    async def async_press(self) -> None:
+        """Send DisableAcidDosingForPeriod with period=0 to cancel inhibit."""
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_action(
+                ChlorinatorActions.DisableAcidDosingForPeriod,
+                period_minutes=0,
+            )
+        await self.coordinator.async_request_refresh()
+
+
+class ChlorinatorResetStatisticsButton(ChlorinatorButtonBase):
+    """Button to reset chlorinator statistics."""
+
+    _attr_icon = "mdi:chart-bar"
+    _attr_name = "Reset Statistics"
+    _attr_unique_id = "pool01_reset_statistics_button"
+    _action = ChlorinatorActions.ResetStatistics
+
+
+class ChlorinatorTriggerCellReversalButton(ChlorinatorButtonBase):
+    """Button to trigger cell reversal."""
+
+    _attr_icon = "mdi:swap-horizontal"
+    _attr_name = "Trigger Cell Reversal"
+    _attr_unique_id = "pool01_trigger_cell_reversal_button"
+    _action = ChlorinatorActions.TriggerCellReversal

--- a/custom_components/astralpool_chlorinator/coordinator.py
+++ b/custom_components/astralpool_chlorinator/coordinator.py
@@ -1,6 +1,7 @@
 """Data coordinator for receiving Chlorinator updates."""
 
 from datetime import timedelta
+import asyncio
 import logging
 from typing import Any
 
@@ -28,6 +29,7 @@ class ChlorinatorDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.data = {}
         self.chlorinator = chlorinator
+        self._ble_lock = asyncio.Lock()
         self.device_info = DeviceInfo(
             identifiers={(DOMAIN, "1234")},
             manufacturer="Astral Pool",
@@ -36,12 +38,13 @@ class ChlorinatorDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
-        try:
-            data = await self.chlorinator.async_gatherdata()
-        except Exception as exc:
-            _LOGGER.warning("Failed _gatherdata")
-            data = {}
-            raise UpdateFailed("Error communicating with API") from exc
-        if data != {}:
-            self.data = data
-        return self.data
+        async with self._ble_lock:
+            try:
+                data = await self.chlorinator.async_gatherdata()
+            except Exception as exc:
+                _LOGGER.warning("Failed _gatherdata: %s", exc, exc_info=True)
+                data = {}
+                raise UpdateFailed("Error communicating with API") from exc
+            if data != {}:
+                self.data = data
+            return self.data

--- a/custom_components/astralpool_chlorinator/coordinator.py
+++ b/custom_components/astralpool_chlorinator/coordinator.py
@@ -25,7 +25,7 @@ class ChlorinatorDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=60),
+            update_interval=timedelta(seconds=30),
         )
         self.data = {}
         self.chlorinator = chlorinator

--- a/custom_components/astralpool_chlorinator/coordinator.py
+++ b/custom_components/astralpool_chlorinator/coordinator.py
@@ -25,7 +25,7 @@ class ChlorinatorDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=30),
+            update_interval=timedelta(seconds=60),
         )
         self.data = {}
         self.chlorinator = chlorinator

--- a/custom_components/astralpool_chlorinator/manifest.json
+++ b/custom_components/astralpool_chlorinator/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "local_polling",
   "requirements": [
     "bluetooth-data-tools>=0.4.0",
-    "pychlorinator>=0.2.14b2"
+    "pychlorinator>=0.3.0"
   ],
   "version": "0.1.14"
 }

--- a/custom_components/astralpool_chlorinator/manifest.json
+++ b/custom_components/astralpool_chlorinator/manifest.json
@@ -9,7 +9,7 @@
   "codeowners": [
     "@pbutterworth"
   ],
-  "config_flow": false,
+  "config_flow": true,
   "dependencies": [
     "bluetooth_adapters"
   ],
@@ -21,5 +21,5 @@
     "bluetooth-data-tools>=0.4.0",
     "pychlorinator>=0.2.14b2"
   ],
-  "version": "0.1.13b1"
+  "version": "0.1.14"
 }

--- a/custom_components/astralpool_chlorinator/number.py
+++ b/custom_components/astralpool_chlorinator/number.py
@@ -82,16 +82,12 @@ class ChlorinatorPhSetpoint(
 class ChlorinatorChlorineSetpoint(
     CoordinatorEntity[ChlorinatorDataUpdateCoordinator], NumberEntity
 ):
-    """Number entity for chlorine output setpoint (manual mode, 0-8)."""
+    """Number entity for chlorine output setpoint — dynamic based on control mode."""
 
     _attr_icon = "mdi:beaker-check-outline"
     _attr_name = "Chlorine Output"
     _attr_unique_id = "pool01_chlorine_setpoint_number"
-    _attr_native_min_value = 0
-    _attr_native_max_value = 8
-    _attr_native_step = 1
     _attr_mode = NumberMode.SLIDER
-    _attr_native_unit_of_measurement = None
 
     def __init__(self, coordinator: ChlorinatorDataUpdateCoordinator) -> None:
         """Initialize the entity."""
@@ -102,7 +98,36 @@ class ChlorinatorChlorineSetpoint(
         return DEVICE_INFO
 
     @property
-    def native_value(self) -> int | None:
+    def _is_automatic(self) -> bool:
+        from pychlorinator.chlorinator_parsers import ChlorineControlTypes
+        return self.coordinator.data.get("chlorine_control_type") == ChlorineControlTypes.Automatic
+
+    @property
+    def native_min_value(self) -> float:
+        if self._is_automatic:
+            return float(self.coordinator.data.get("minimum_orp_setpoint", 200))
+        return 0
+
+    @property
+    def native_max_value(self) -> float:
+        if self._is_automatic:
+            return float(self.coordinator.data.get("maximum_orp_setpoint", 800))
+        return 8
+
+    @property
+    def native_step(self) -> float:
+        if self._is_automatic:
+            return 10
+        return 1
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        if self._is_automatic:
+            return "mV"
+        return None
+
+    @property
+    def native_value(self) -> float | None:
         return self.coordinator.data.get("chlorine_control_setpoint")
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/astralpool_chlorinator/number.py
+++ b/custom_components/astralpool_chlorinator/number.py
@@ -1,0 +1,153 @@
+"""Platform for number integration."""
+from __future__ import annotations
+
+import logging
+import asyncio
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberMode,
+)
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import ChlorinatorDataUpdateCoordinator
+from .models import ChlorinatorData
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DEVICE_INFO = {
+    "identifiers": {(DOMAIN, "POOL01")},
+    "name": "POOL01",
+    "model": "Viron eQuilibrium",
+    "manufacturer": "Astral Pool",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Chlorinator number entities from a config entry."""
+    data: ChlorinatorData = hass.data[DOMAIN][entry.entry_id]
+    entities = [
+        ChlorinatorPhSetpoint(data.coordinator),
+        ChlorinatorChlorineSetpoint(data.coordinator),
+        ChlorinatorAcidDosingInhibitPeriod(data.coordinator),
+    ]
+    async_add_entities(entities)
+
+
+class ChlorinatorPhSetpoint(
+    CoordinatorEntity[ChlorinatorDataUpdateCoordinator], NumberEntity
+):
+    """Number entity for pH setpoint."""
+
+    _attr_icon = "mdi:ph"
+    _attr_name = "pH Setpoint"
+    _attr_unique_id = "pool01_ph_setpoint_number"
+    _attr_native_min_value = 6.0
+    _attr_native_max_value = 8.0
+    _attr_native_step = 0.1
+    _attr_mode = NumberMode.BOX
+    _attr_native_unit_of_measurement = None
+
+    def __init__(self, coordinator: ChlorinatorDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return DEVICE_INFO
+
+    @property
+    def native_value(self) -> float | None:
+        return self.coordinator.data.get("ph_control_setpoint")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the pH setpoint."""
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_setup(
+                ph_control_setpoint=round(value, 1)
+            )
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()
+
+
+class ChlorinatorChlorineSetpoint(
+    CoordinatorEntity[ChlorinatorDataUpdateCoordinator], NumberEntity
+):
+    """Number entity for chlorine output setpoint (manual mode, 0-8)."""
+
+    _attr_icon = "mdi:beaker-check-outline"
+    _attr_name = "Chlorine Output"
+    _attr_unique_id = "pool01_chlorine_setpoint_number"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 8
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_unit_of_measurement = None
+
+    def __init__(self, coordinator: ChlorinatorDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return DEVICE_INFO
+
+    @property
+    def native_value(self) -> int | None:
+        return self.coordinator.data.get("chlorine_control_setpoint")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the chlorine output level."""
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_setup(
+                chlorine_control_setpoint=int(value)
+            )
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()
+
+
+class ChlorinatorAcidDosingInhibitPeriod(
+    CoordinatorEntity[ChlorinatorDataUpdateCoordinator], NumberEntity
+):
+    """Number entity for acid dosing inhibit period in minutes."""
+
+    _attr_icon = "mdi:timer-outline"
+    _attr_name = "Acid Dosing Inhibit Period"
+    _attr_unique_id = "pool01_acid_dosing_inhibit_period_number"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 1440
+    _attr_native_step = 15
+    _attr_mode = NumberMode.BOX
+    _attr_native_unit_of_measurement = "min"
+
+    def __init__(self, coordinator: ChlorinatorDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return DEVICE_INFO
+
+    @property
+    def native_value(self) -> int | None:
+        return self.coordinator.data.get("acid_dosing_inhibit_time_remaining")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the acid dosing inhibit period."""
+        from pychlorinator.chlorinator_parsers import ChlorinatorActions
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_action(
+                ChlorinatorActions.DisableAcidDosingForPeriod,
+                period_minutes=int(value),
+            )
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/astralpool_chlorinator/select.py
+++ b/custom_components/astralpool_chlorinator/select.py
@@ -31,7 +31,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Chlorinator from a config entry."""
     data: ChlorinatorData = hass.data[DOMAIN][entry.entry_id]
-    entities = [ChlorinatorModeSelect(data.coordinator), ChlorinatorSpeedSelect(data.coordinator)]
+    entities = [
+        ChlorinatorModeSelect(data.coordinator),
+        ChlorinatorSpeedSelect(data.coordinator),
+        ChlorinatorDefaultManualSpeedSelect(data.coordinator),
+    ]
     async_add_entities(entities)
 
 
@@ -73,7 +77,6 @@ class ChlorinatorModeSelect(
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option"""
-        action: chlorinator_parsers.ChlorinatorActions.NoAction
         if option == "Off":
             action = chlorinator_parsers.ChlorinatorActions.Off
         elif option == "Auto":
@@ -82,8 +85,8 @@ class ChlorinatorModeSelect(
             action = chlorinator_parsers.ChlorinatorActions.Manual
         else:
             action = chlorinator_parsers.ChlorinatorActions.NoAction
-
-        await self.coordinator.chlorinator.async_write_action(action)
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_action(action)
         await asyncio.sleep(2)
         await self.coordinator.async_request_refresh()
 
@@ -127,7 +130,6 @@ class ChlorinatorSpeedSelect(
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option"""
-        action: chlorinator_parsers.ChlorinatorActions.NoAction
         if option == "Low":
             action = chlorinator_parsers.ChlorinatorActions.Low
         elif option == "Medium":
@@ -136,7 +138,59 @@ class ChlorinatorSpeedSelect(
             action = chlorinator_parsers.ChlorinatorActions.High
         else:
             action = chlorinator_parsers.ChlorinatorActions.NoAction
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_action(action)
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()
 
-        await self.coordinator.chlorinator.async_write_action(action)
+class ChlorinatorDefaultManualSpeedSelect(
+    CoordinatorEntity[ChlorinatorDataUpdateCoordinator], SelectEntity
+):
+    """Representation of a Chlorinator Default Manual Speed Select entity."""
+
+    _attr_icon = "mdi:speedometer"
+    _attr_options = ["Low", "Medium", "High"]
+    _attr_name = "Default Manual Speed"
+    _attr_unique_id = "pool01_default_manual_speed_select"
+
+    def __init__(
+        self,
+        coordinator: ChlorinatorDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        return {
+            "identifiers": {(DOMAIN, "POOL01")},
+            "name": "POOL01",
+            "model": "Viron eQuilibrium",
+            "manufacturer": "Astral Pool",
+        }
+
+    @property
+    def current_option(self):
+        speed = self.coordinator.data.get("default_manual_on_speed")
+        if speed is chlorinator_parsers.SpeedLevels.Low:
+            return "Low"
+        elif speed is chlorinator_parsers.SpeedLevels.Medium:
+            return "Medium"
+        else:
+            return "High"
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the default manual speed."""
+        from pychlorinator.chlorinator_parsers import SpeedLevels
+        if option == "Low":
+            speed = SpeedLevels.Low
+        elif option == "Medium":
+            speed = SpeedLevels.Medium
+        else:
+            speed = SpeedLevels.High
+        async with self.coordinator._ble_lock:
+            await self.coordinator.chlorinator.async_write_setup(
+                default_manual_on_speed=speed
+            )
         await asyncio.sleep(2)
         await self.coordinator.async_request_refresh()

--- a/custom_components/astralpool_chlorinator/sensor.py
+++ b/custom_components/astralpool_chlorinator/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -20,7 +21,6 @@ from homeassistant.helpers.update_coordinator import (
 from .coordinator import ChlorinatorDataUpdateCoordinator
 from .models import ChlorinatorData
 from .const import DOMAIN
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,6 +97,86 @@ CHLORINATOR_SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.ENUM,
         state_class=None,
     ),
+    "highest_ph_measured": SensorEntityDescription(
+        key="highest_ph_measured",
+        icon="mdi:ph",
+        name="Highest pH measured",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "lowest_ph_measured": SensorEntityDescription(
+        key="lowest_ph_measured",
+        icon="mdi:ph",
+        name="Lowest pH measured",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "highest_orp_measured": SensorEntityDescription(
+        key="highest_orp_measured",
+        icon="mdi:beaker-outline",
+        name="Highest ORP measured",
+        native_unit_of_measurement="mV",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "lowest_orp_measured": SensorEntityDescription(
+        key="lowest_orp_measured",
+        icon="mdi:beaker-outline",
+        name="Lowest ORP measured",
+        native_unit_of_measurement="mV",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "cell_reversal_count": SensorEntityDescription(
+        key="cell_reversal_count",
+        icon="mdi:swap-horizontal",
+        name="Cell reversal count",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "cell_running_time": SensorEntityDescription(
+        key="cell_running_time",
+        icon="mdi:timer-outline",
+        name="Cell running time",
+        native_unit_of_measurement="h",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "low_salt_cell_running_time": SensorEntityDescription(
+        key="low_salt_cell_running_time",
+        icon="mdi:timer-alert-outline",
+        name="Low salt cell running time",
+        native_unit_of_measurement="h",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "previous_days_cell_load": SensorEntityDescription(
+        key="previous_days_cell_load",
+        icon="mdi:chart-bar",
+        name="Previous day cell load",
+        native_unit_of_measurement="%",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "acid_dosing_inhibit_status": SensorEntityDescription(
+        key="acid_dosing_inhibit_status",
+        icon="mdi:beaker-off-outline",
+        name="Acid dosing inhibit status",
+        native_unit_of_measurement=None,
+        device_class=SensorDeviceClass.ENUM,
+        state_class=None,
+    ),
+    "acid_dosing_inhibit_time_remaining": SensorEntityDescription(
+        key="acid_dosing_inhibit_time_remaining",
+        icon="mdi:timer-outline",
+        name="Acid dosing inhibit time remaining",
+        native_unit_of_measurement="min",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 }
 
 
@@ -110,7 +190,6 @@ async def async_setup_entry(
     entities = [
         ChlorinatorSensor(data.coordinator, sensor_desc)
         for sensor_desc in CHLORINATOR_SENSOR_TYPES
-        # if sensorDesc in CHLORINATOR_SENSOR_TYPES
     ]
     async_add_entities(entities)
 
@@ -149,4 +228,7 @@ class ChlorinatorSensor(
 
     @property
     def native_value(self):
-        return self.coordinator.data.get(self._sensor)
+        value = self.coordinator.data.get(self._sensor)
+        if isinstance(value, timedelta):
+            return value.total_seconds() / 3600
+        return value

--- a/info.md
+++ b/info.md
@@ -15,7 +15,9 @@
 | --------------- | ------------------------------------------------------------------------- |
 | `binary_sensor` | Show something `True` or `False`.                                         |
 | `sensor`        | Show info from Astral Pool Viron eQuilibrium Chlorinator API.             |
-| `select`        | Control the chlorinator mode (off/auto/manual)                            |
+| `select`        | Control the chlorinator mode (off/auto/manual), pump speed, and default manual speed. |
+| `number`        | Set pH setpoint, chlorine output level (0-8 manual / ORP mV automatic), and acid dosing inhibit period. |
+| `button`        | Dismiss info message, disable/re-enable acid dosing, reset statistics, trigger cell reversal. |
 
 
 {% if not installed %}


### PR DESCRIPTION
## Summary

Adds write control entities for the chlorinator, enabling pH setpoint, chlorine output level, default manual speed, and acid dosing control from Home Assistant.

## Dependencies
- Requires pychlorinator with `async_write_setup()` support:
  - pbutterworth/pychlorinator#18 (pending merge)
  - Or once merged and published: pychlorinator >= 0.3.x
- Recommended: #10 (BLE lock) should be merged first to prevent concurrent connection issues when using write controls

## New platforms

### `number` platform
- **pH Setpoint** — write pH target (6.0-8.0, step 0.1)
- **Chlorine Output** — dynamic entity that adapts based on `chlorine_control_type`: Manual mode (no ORP probe) range 0-8 step 1 no unit; Automatic mode (ORP probe connected) range `minimum_orp_setpoint` to `maximum_orp_setpoint` mV (200-800 mV on EQ25) step 10 — min/max read dynamically from device capabilities
- **Acid Dosing Inhibit Period** — set inhibit duration (0-1440 min, step 15)

### `button` platform
- Dismiss info message
- Disable acid dosing indefinitely
- Re-enable acid dosing (sends DisableAcidDosingForPeriod with period=0)
- Reset statistics
- Trigger cell reversal

### `select` platform (additions)
- **Default Manual Speed** — set default pump speed for manual mode (Low/Medium/High)

## Issues addressed
- Closes #5 (ORP and pH setpoint control)

## Testing
- Tested on Home Assistant 2026.4.4 and 2026.5.1
- Tested on Astral Pool Viron EQ25 via ESPHome BLE proxy
- pH setpoint write confirmed working
- Chlorine output write confirmed working in both manual mode (0-8) and automatic mode (ORP mV) with ORP probe connected
- Default manual speed write confirmed working
- Acid dosing disable/re-enable confirmed working
- Acid dosing inhibit period confirmed working
- Dynamic min/max/unit for chlorine output confirmed with ORP probe connected

## Notes
- Raw ORP mV reading is NOT available from the EQ25 BLE state characteristic — only categorised status (Ok/Low/High etc.) is available. This addresses #8 — the device firmware does not expose raw ORP mV via BLE.
- Re-enable acid dosing uses period=0 — verify this cancels inhibit on your unit
- Reset statistics and trigger cell reversal buttons implemented but not tested (destructive operations)
- Only tested on Viron EQ25 — other Viron models should work but are untested. Issue #16 confirms V25 read compatibility — write operations untested on V25
- Halo series: no changes to halochlorinator.py, no Halo impact

## Compatibility
- Tested on Home Assistant 2026.4.4 and 2026.5.1
- Viron EQ25 confirmed working
- Other Viron models untested

## Related PRs
- pbutterworth/pychlorinator#18 — required pychlorinator changes
- #10 — recommended BLE lock