### PR TITLE
Update actions/checkout to v4 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - name: HACS validation
         uses: "hacs/action@main"
         with:


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 on Actions runners. `actions/checkout@v3` runs on Node.js 20 and will stop working on June 2nd, 2026 when Node.js 24 becomes the default.

## Changes
- `.github/workflows/validate.yaml`: `actions/checkout@v3` → `actions/checkout@v4`

## References
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/